### PR TITLE
週間ビューのタスクグループ表示を改善

### DIFF
--- a/src/components/WeeklySection.tsx
+++ b/src/components/WeeklySection.tsx
@@ -42,13 +42,17 @@ function groupItems(items: ListItem[]): TaskGroup[] {
 	return groups;
 }
 
+const INDENT_UNIT = 4;
+
 function ListItemRow({
 	item,
 	isParent,
+	hasChildren = false,
 	baseIndent = 0,
 }: {
 	item: ListItem;
 	isParent: boolean;
+	hasChildren?: boolean;
 	baseIndent?: number;
 }) {
 	const status = getTaskStatus(item.kind);
@@ -65,7 +69,10 @@ function ListItemRow({
 					8 +
 					(isParent
 						? 0
-						: Math.max(0, Math.floor((item.indent - baseIndent) / 4) - 1) * 16),
+						: Math.max(
+								0,
+								Math.floor((item.indent - baseIndent) / INDENT_UNIT) - 1,
+							) * 16),
 				paddingTop: isParent ? 6 : 3,
 				paddingBottom: isParent ? 4 : 3,
 				fontSize: "var(--font-base)",
@@ -78,7 +85,7 @@ function ListItemRow({
 				style={{
 					flex: 1,
 					color: isDimmed ? "var(--text-muted)" : "var(--text)",
-					fontWeight: isParent ? 500 : "normal",
+					fontWeight: isParent && hasChildren ? 500 : "normal",
 					textDecoration:
 						status === "done" || status === "cancelled"
 							? "line-through"
@@ -105,7 +112,11 @@ function ListItemRow({
 function TaskGroupBlock({ group }: { group: TaskGroup }) {
 	return (
 		<div style={styles.taskGroup}>
-			<ListItemRow item={group.parent} isParent={true} />
+			<ListItemRow
+				item={group.parent}
+				isParent={true}
+				hasChildren={group.children.length > 0}
+			/>
 			{group.children.length > 0 && (
 				<div style={styles.childrenBlock}>
 					{group.children.map((child) => (


### PR DESCRIPTION
## 変更の概要
週間ビューで親タスクと子タスクのグループが視覚的に区別しにくかった問題を改善します。
親タスクごとにグループ化し、左ボーダーとインデントで階層構造を表現します。

## 主な変更点
- フラットなタスクリストを親子グループ単位で描画するよう変更（`groupItems` / `TaskGroupBlock`）
- 親タスクを `fontWeight: 500` で強調
- 子タスクブロックに左ボーダー（`2px solid`）を追加してグループの結束感を表現
- グループ間に `borderBottom` で区切り線を追加（グループ内の行間ボーダーは除去）
- 3階層以上のネスト（孫・曾孫）にも `indent` 差分に応じた追加インデントを適用

## 変更の背景
親タスクと子タスクが同じインデントレベル・同じスタイルで表示されており、タスクグループの境界が分かりにくかった。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **UI改善**
  * タスク項目を連続したインデントに基づき親子で自動グループ化し、親項目と子項目をまとめて表示します。
  * 親行は強調表示され、子項目はインデントされたブロック内で表示されるため、階層構造が視覚的にわかりやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->