### PR TITLE
リリースワークフローの追加とアイコンライセンス同梱

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths: ['src-tauri/Cargo.toml']
+  workflow_dispatch:
+
+concurrency:
+  group: auto-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  validate-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::This workflow can only be run from the main branch (current: ${{ github.ref }})"
+          exit 1
+
+  create-release:
+    needs: validate-branch
+    permissions:
+      contents: write
+    uses: rysk-tanaka/workflows/.github/workflows/release-on-version-change.yml@main
+    with:
+      version_source: command
+      version_command: "awk '/^\\[package\\]$/{p=1;next}/^\\[/{p=0}p&&/^version[[:space:]]*=/{gsub(/\"/,\"\",$3);print $3;exit}' src-tauri/Cargo.toml"
+      tag_prefix: v
+      force_released_output: ${{ github.event_name == 'workflow_dispatch' }}
+    secrets: inherit
+
+  upload-artifacts:
+    needs: create-release
+    if: needs.create-release.outputs.released == 'true'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+          - runner: macos-15-intel
+          - runner: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm tauri build
+      - name: Upload macOS artifacts
+        if: runner.os == 'macOS'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.create-release.outputs.tag }}" \
+            src-tauri/target/release/bundle/dmg/*.dmg --clobber
+      - name: Upload Linux artifacts
+        if: runner.os == 'Linux'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.create-release.outputs.tag }}" \
+            src-tauri/target/release/bundle/deb/*.deb \
+            src-tauri/target/release/bundle/appimage/*.AppImage --clobber

--- a/TODO.md
+++ b/TODO.md
@@ -30,5 +30,5 @@
 ## CI / リリース
 
 - [ ] フロントエンド E2E テストの CI ジョブ追加
-- [ ] Tauri アプリのリリースビルド・配布パイプライン（GitHub Releases 等）
-- [ ] 配布物にアイコンライセンスファイルを同梱する (#12)
+- [x] ~~Tauri アプリのリリースビルド・配布パイプライン（GitHub Releases 等）~~ → `auto-release.yml` で macOS / Linux ビルド・配布を自動化
+- [x] ~~配布物にアイコンライセンスファイルを同梱する (#12)~~ → `bundle.resources` で `assets/LICENSE` を `ICON_LICENSE` として同梱

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,9 @@
       "icons/icon.ico",
       "icons/icon.icns",
       "icons/icon.png"
-    ]
+    ],
+    "resources": {
+      "../assets/LICENSE": "ICON_LICENSE"
+    }
   }
 }


### PR DESCRIPTION
## 変更の概要
Tauri アプリの自動リリースパイプラインを構築し、配布物にアイコンライセンスファイルを同梱するようにしました。

## 主な変更点
- `auto-release.yml` を新規作成し、`src-tauri/Cargo.toml` のバージョン変更で GitHub Release + 成果物アップロードを自動化
- macOS (ARM / Intel) と Linux (x86_64) の 3 プラットフォームで Tauri ビルドを実行し、DMG / deb / AppImage をリリースに添付
- 共有ワークフロー `rysk-tanaka/workflows` の `release-on-version-change.yml` を `version_source: command` で利用（`src-tauri/Cargo.toml` からバージョン抽出）

## 他、軽微な修正
- `tauri.conf.json` の `bundle.resources` に `assets/LICENSE` → `ICON_LICENSE` を追加し、配布物にアイコンライセンスを同梱
- `TODO.md` の該当 2 項目を完了済みに更新

## 変更の背景
TODO に記載されていたリリースビルド・配布パイプライン整備と、アイコンライセンスファイルの同梱対応（#12）をまとめて実施しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  - macOSおよびLinux向けリリース成果物の自動ビルドとアップロード機能を追加
  - ビルド出力にライセンスファイルを自動同梱するよう設定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->