### PR TITLE
Weekly Note サマリの自動生成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ pnpm exec tsc --noEmit -p tsconfig.app.json
 | `create_note` | Daily/Weekly Note 生成（テンプレート展開、既存なら既存パスを返す） |
 
 | `get_ai_availability` | Apple Intelligence の利用可否を返す |
+| `generate_weekly_summary` | 指定週の完了タスクを AI で要約し Weekly Note に追記 |
 
 コマンド関数は `lib.rs` 内で非 `pub` にすること（lib/bin 間のマクロ重複を回避するため）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,8 @@ pnpm exec tsc --noEmit -p tsconfig.app.json
 | `create_note` | Daily/Weekly Note 生成（テンプレート展開、既存なら既存パスを返す） |
 
 | `get_ai_availability` | Apple Intelligence の利用可否を返す |
-| `generate_weekly_summary` | 指定週の完了タスクを AI で要約し Weekly Note に追記 |
+| `generate_weekly_summary` | 指定週の完了タスクを AI で要約して返す（ファイルは更新しない） |
+| `save_weekly_summary` | AI 要約結果を Weekly Note に追記・保存 |
 
 コマンド関数は `lib.rs` 内で非 `pub` にすること（lib/bin 間のマクロ重複を回避するため）。
 

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@
 
 - [x] ~~Foundation Models Swift Bridge 基盤（#17）~~ → `swift-rs` + SwiftPM で Rust↔Swift FFI 実装済み
 - [ ] スタンドアップ報告文の自動生成（#18）
-- [ ] Weekly Note サマリの自動生成（#19）
+- [x] ~~Weekly Note サマリの自動生成（#19）~~ → `generate_weekly_summary` コマンドで AI サマリ生成・追記を実装
 - [ ] 自然言語 Vault 検索（#20）
 
 ## テスト

--- a/src-tauri/src/ai_bridge.rs
+++ b/src-tauri/src/ai_bridge.rs
@@ -8,8 +8,6 @@
 //! メインスレッドから呼び出すとデッドロックする可能性がある。Tauri のワーカースレッドから呼ぶこと。
 //! `is_available()` は非ブロッキングであり、任意のスレッドから安全に呼び出せる。
 
-// generate() と関連型は後続 issue (#18, #19, #20) で使用される
-#[allow(dead_code)]
 #[cfg(target_os = "macos")]
 mod platform {
     use serde::Deserialize;
@@ -53,7 +51,6 @@ mod platform {
     }
 }
 
-#[allow(dead_code)]
 #[cfg(not(target_os = "macos"))]
 mod platform {
     pub fn is_available() -> bool {
@@ -66,7 +63,7 @@ mod platform {
 }
 
 pub use platform::is_available;
-// generate は後続 issue で pub use する
+pub use platform::generate;
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_store::StoreExt;
 
-use task_parser::{VaultSummary, WeeklyTasks};
+use task_parser::{VaultSummary, WeeklyTaskSummary, WeeklyTasks};
 use vault_watcher::VaultDebouncer;
 
 const STORE_FILE: &str = "settings.json";
@@ -147,6 +147,96 @@ async fn create_note(
         })
 }
 
+// ---- AI 週次サマリ生成 ----
+
+const WEEKLY_SUMMARY_SYSTEM_PROMPT: &str = "\
+あなたはエンジニアの週次振り返りレポートを作成するアシスタントです。\
+以下の完了・進行中タスクリストから、プロジェクトをまたいだ週次の成果と\
+学びを3〜5文の自然な日本語で要約してください。\
+箇条書きは使わず、段落形式で記述してください。";
+
+const NO_TASKS_MESSAGE: &str = "今週は記録されたタスクがありません。";
+
+fn format_tasks_for_ai(summary: &WeeklyTaskSummary) -> String {
+    use std::collections::BTreeMap;
+    use std::fmt::Write;
+
+    let mut by_project: BTreeMap<&str, Vec<String>> = BTreeMap::new();
+
+    for task in &summary.completed {
+        let entry = by_project.entry(&task.project).or_default();
+        let date_str = task
+            .done_date
+            .map_or(String::new(), |d| format!(" (完了: {d})"));
+        entry.push(format!("- [x] {}{date_str}", task.text));
+    }
+
+    for task in &summary.started {
+        let entry = by_project.entry(&task.project).or_default();
+        let date_str = task
+            .start
+            .map_or(String::new(), |d| format!(" (開始: {d})"));
+        entry.push(format!("- [/] {}{date_str}", task.text));
+    }
+
+    let mut output = String::new();
+    for (project, tasks) in &by_project {
+        let _ = writeln!(output, "【{project}】");
+        for task in tasks {
+            let _ = writeln!(output, "{task}");
+        }
+        output.push('\n');
+    }
+
+    output
+}
+
+/// 指定週の AI 週次サマリを生成し、Weekly Note に追記する
+#[tauri::command]
+async fn generate_weekly_summary(
+    week: String,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    if !ai_bridge::is_available() {
+        return Err("AI features are not available on this system".to_string());
+    }
+
+    let vault_root = state
+        .vault_root
+        .lock()
+        .map_err(|e| e.to_string())?
+        .clone()
+        .ok_or("Vaultが設定されていません")?;
+
+    let (week_start, week_end) =
+        task_parser::parse_iso_week(&week).map_err(|e| e.to_string())?;
+
+    let note_path = note_creator::weekly_note_path(&vault_root, &week);
+    if !note_path.exists() {
+        return Err(format!("Weekly Note が見つかりません: {}", note_path.display()));
+    }
+
+    let task_summary =
+        task_parser::collect_weekly_done_tasks(&vault_root, week_start, week_end)
+            .map_err(|e| e.to_string())?;
+
+    let summary_text = if task_summary.completed.is_empty() && task_summary.started.is_empty() {
+        NO_TASKS_MESSAGE.to_string()
+    } else {
+        let user_prompt = format_tasks_for_ai(&task_summary);
+        let system = WEEKLY_SUMMARY_SYSTEM_PROMPT.to_string();
+
+        tokio::task::spawn_blocking(move || ai_bridge::generate(&system, &user_prompt))
+            .await
+            .map_err(|e| e.to_string())??
+    };
+
+    note_creator::append_ai_summary(&note_path, &summary_text)
+        .map_err(|e| e.to_string())?;
+
+    Ok(summary_text)
+}
+
 // ---- 起動時復元 ----
 
 /// store から前回の Vault パスを復元し、存在すればメモリ + ファイル監視を開始する
@@ -204,6 +294,7 @@ pub fn run() {
             get_weekly_tasks,
             create_note,
             get_ai_availability,
+            generate_weekly_summary,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,9 +151,15 @@ async fn create_note(
 
 const WEEKLY_SUMMARY_SYSTEM_PROMPT: &str = "\
 あなたはエンジニアの週次振り返りレポートを作成するアシスタントです。\
-以下の完了・進行中タスクリストから、プロジェクトをまたいだ週次の成果と\
-学びを3〜5文の自然な日本語で要約してください。\
-箇条書きは使わず、段落形式で記述してください。";
+以下の完了・進行中タスクリストから、プロジェクトごとの週次サマリを作成してください。\
+\n\
+フォーマット:\n\
+- プロジェクトごとに【プロジェクト名】の見出しで区切る\n\
+- 各プロジェクトの成果を1〜2文で簡潔に述べる\n\
+- 自己言及しない（「今週は…に焦点を当てました」のような書き出しは避ける）\n\
+- 成果を直接述べる\n\
+- 最後に全体を俯瞰した1文を追加する（任意）\n\
+- 自然な日本語で記述する";
 
 const NO_TASKS_MESSAGE: &str = "今週は記録されたタスクがありません。";
 
@@ -191,7 +197,7 @@ fn format_tasks_for_ai(summary: &WeeklyTaskSummary) -> String {
     output
 }
 
-/// 指定週の AI 週次サマリを生成し、Weekly Note に追記する
+/// 指定週の AI 週次サマリを生成して返す（ノートへの書き込みは行わない）
 #[tauri::command]
 async fn generate_weekly_summary(
     week: String,
@@ -220,21 +226,45 @@ async fn generate_weekly_summary(
         task_parser::collect_weekly_done_tasks(&vault_root, week_start, week_end)
             .map_err(|e| e.to_string())?;
 
-    let summary_text = if task_summary.completed.is_empty() && task_summary.started.is_empty() {
-        NO_TASKS_MESSAGE.to_string()
-    } else {
-        let user_prompt = format_tasks_for_ai(&task_summary);
-        let system = WEEKLY_SUMMARY_SYSTEM_PROMPT.to_string();
+    if task_summary.completed.is_empty() && task_summary.started.is_empty() {
+        return Ok(NO_TASKS_MESSAGE.to_string());
+    }
 
-        tokio::task::spawn_blocking(move || ai_bridge::generate(&system, &user_prompt))
-            .await
-            .map_err(|e| e.to_string())??
-    };
+    let user_prompt = format_tasks_for_ai(&task_summary);
+    let system = WEEKLY_SUMMARY_SYSTEM_PROMPT.to_string();
 
-    note_creator::append_ai_summary(&note_path, &summary_text)
-        .map_err(|e| e.to_string())?;
+    tokio::task::spawn_blocking(move || ai_bridge::generate(&system, &user_prompt))
+        .await
+        .map_err(|e| e.to_string())?
+}
 
-    Ok(summary_text)
+/// 生成済みサマリを Weekly Note に追記する
+#[tauri::command]
+async fn save_weekly_summary(
+    week: String,
+    summary: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let vault_root = state
+        .vault_root
+        .lock()
+        .map_err(|e| e.to_string())?
+        .clone()
+        .ok_or("Vaultが設定されていません")?;
+
+    // ISO 週形式を検証してパストラバーサルを防止
+    task_parser::parse_iso_week(&week).map_err(|e| e.to_string())?;
+
+    let note_path = note_creator::weekly_note_path(&vault_root, &week);
+    if !note_path.exists() {
+        return Err(format!("Weekly Note が見つかりません: {}", note_path.display()));
+    }
+
+    let today = chrono::Local::now().format("%Y-%m-%d");
+    let with_date = format!("*生成日: {today}*\n\n{summary}");
+
+    note_creator::append_ai_summary(&note_path, &with_date)
+        .map_err(|e| e.to_string())
 }
 
 // ---- 起動時復元 ----
@@ -295,6 +325,7 @@ pub fn run() {
             create_note,
             get_ai_availability,
             generate_weekly_summary,
+            save_weekly_summary,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,7 +204,7 @@ async fn generate_weekly_summary(
     state: State<'_, AppState>,
 ) -> Result<String, String> {
     if !ai_bridge::is_available() {
-        return Err("AI features are not available on this system".to_string());
+        return Err("この環境では AI 機能を利用できません".to_string());
     }
 
     let vault_root = state
@@ -223,7 +223,7 @@ async fn generate_weekly_summary(
     }
 
     let task_summary =
-        task_parser::collect_weekly_done_tasks(&vault_root, week_start, week_end)
+        task_parser::collect_weekly_tasks(&vault_root, week_start, week_end)
             .map_err(|e| e.to_string())?;
 
     if task_summary.completed.is_empty() && task_summary.started.is_empty() {

--- a/src-tauri/src/note_creator.rs
+++ b/src-tauri/src/note_creator.rs
@@ -69,51 +69,67 @@ pub fn weekly_note_path(vault_root: &Path, week_str: &str) -> PathBuf {
 }
 
 const AI_SUMMARY_HEADING: &str = "## AI 週次サマリ";
+const AI_SUMMARY_END: &str = "<!-- /ai-weekly-summary -->";
 
 /// Weekly Note に AI サマリセクションを追記・上書きする。
 /// 既に `## AI 週次サマリ` セクションがある場合は内容を差し替え、
 /// なければファイル末尾に追加する。
+/// セクションの終端は `<!-- /ai-weekly-summary -->` デリミタで管理し、
+/// AI 生成テキスト内の `##` 見出しと区別する。
 pub fn append_ai_summary(note_path: &Path, summary: &str) -> anyhow::Result<()> {
     let content = std::fs::read_to_string(note_path)
         .with_context(|| format!("failed to read: {}", note_path.display()))?;
 
-    let new_content = if let Some(heading_start) = content.find(AI_SUMMARY_HEADING) {
-        // セクション開始位置（ヘッダ行の末尾以降）
+    let section_body = format!("\n\n{summary}\n\n{AI_SUMMARY_END}\n");
+
+    // 行頭の `## AI 週次サマリ` のみマッチ（部分一致や ### レベルとの誤認を防ぐ）
+    let heading_start = if content.starts_with(AI_SUMMARY_HEADING) {
+        Some(0)
+    } else {
+        content
+            .find(&format!("\n{AI_SUMMARY_HEADING}"))
+            .map(|pos| pos + 1) // '\n' の次の位置
+    };
+
+    let new_content = if let Some(heading_start) = heading_start {
         let after_heading = heading_start + AI_SUMMARY_HEADING.len();
         let rest = &content[after_heading..];
 
-        // 次の ## ヘッダまたは EOF を探す
-        let section_end = rest
-            .find("\n## ")
-            .map_or(content.len(), |pos| after_heading + pos);
+        // end delimiter があればそこまで、なければ次の ## ヘッダか EOF
+        let section_end = if let Some(pos) = rest.find(AI_SUMMARY_END) {
+            let end_marker_end = after_heading + pos + AI_SUMMARY_END.len();
+            // delimiter 直後の改行も含める
+            if content.as_bytes().get(end_marker_end) == Some(&b'\n') {
+                end_marker_end + 1
+            } else {
+                end_marker_end
+            }
+        } else {
+            rest.find("\n## ")
+                .map_or(content.len(), |pos| after_heading + pos)
+        };
 
         let mut result = String::with_capacity(content.len());
         result.push_str(&content[..heading_start]);
         result.push_str(AI_SUMMARY_HEADING);
-        result.push_str("\n\n");
-        result.push_str(summary);
-        result.push('\n');
+        result.push_str(&section_body);
 
         if section_end < content.len() {
             result.push_str(&content[section_end..]);
         }
 
-        // ensure trailing newline
         if !result.ends_with('\n') {
             result.push('\n');
         }
         result
     } else {
-        // セクションが存在しない → 末尾に追加
         let mut result = content.clone();
         if !result.ends_with('\n') {
             result.push('\n');
         }
         result.push('\n');
         result.push_str(AI_SUMMARY_HEADING);
-        result.push_str("\n\n");
-        result.push_str(summary);
-        result.push('\n');
+        result.push_str(&section_body);
         result
     };
 
@@ -242,7 +258,8 @@ mod tests {
 
         append_ai_summary(&note, "新規サマリ").expect("append");
         let content = fs::read_to_string(&note).expect("read");
-        assert!(content.contains("## AI 週次サマリ\n\n新規サマリ\n"));
+        assert!(content.contains("新規サマリ"));
+        assert!(content.contains(AI_SUMMARY_END));
         assert!(content.contains(review_heading));
         assert!(content.ends_with('\n'));
     }
@@ -261,6 +278,30 @@ mod tests {
         assert!(content.contains("更新サマリ"));
         assert!(!content.contains("古い内容"));
         assert!(content.contains("## メモ\n\n残す内容"));
+    }
+
+    #[test]
+    fn append_ai_summary_with_headings_in_body() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let note = tmp.path().join("note.md");
+        fs::write(&note, "# 2026-W13\n\n## メモ\n\n残す内容\n").expect("write");
+
+        let summary_with_headings = "## 成果\n\n良かった\n\n## 課題\n\nもう少し";
+        append_ai_summary(&note, summary_with_headings).expect("first");
+
+        let content = fs::read_to_string(&note).expect("read");
+        assert!(content.contains("## 成果"));
+        assert!(content.contains("## 課題"));
+        assert!(content.contains("## メモ\n\n残す内容"));
+
+        // 2 回目の書き込みで古い AI 内容が完全に置換されること
+        append_ai_summary(&note, "更新済み").expect("second");
+        let content2 = fs::read_to_string(&note).expect("read");
+        assert!(content2.contains("更新済み"));
+        assert!(!content2.contains("## 成果"));
+        assert!(!content2.contains("## 課題"));
+        assert!(content2.contains("## メモ\n\n残す内容"));
+        assert_eq!(content2.matches("## AI 週次サマリ").count(), 1);
     }
 
     #[test]

--- a/src-tauri/src/note_creator.rs
+++ b/src-tauri/src/note_creator.rs
@@ -4,6 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
 use chrono::{Datelike, IsoWeek, Local};
 
 use crate::template;
@@ -60,6 +61,64 @@ fn default_template(kind: &crate::NoteKind, title: &str) -> String {
             "# {title}\n\n## 振り返り\n\n-\n"
         ),
     }
+}
+
+/// Weekly Note のファイルパスを返す（`60_Weekly/{week_str}.md`）
+pub fn weekly_note_path(vault_root: &Path, week_str: &str) -> PathBuf {
+    vault_root.join("60_Weekly").join(format!("{week_str}.md"))
+}
+
+const AI_SUMMARY_HEADING: &str = "## AI 週次サマリ";
+
+/// Weekly Note に AI サマリセクションを追記・上書きする。
+/// 既に `## AI 週次サマリ` セクションがある場合は内容を差し替え、
+/// なければファイル末尾に追加する。
+pub fn append_ai_summary(note_path: &Path, summary: &str) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(note_path)
+        .with_context(|| format!("failed to read: {}", note_path.display()))?;
+
+    let new_content = if let Some(heading_start) = content.find(AI_SUMMARY_HEADING) {
+        // セクション開始位置（ヘッダ行の末尾以降）
+        let after_heading = heading_start + AI_SUMMARY_HEADING.len();
+        let rest = &content[after_heading..];
+
+        // 次の ## ヘッダまたは EOF を探す
+        let section_end = rest
+            .find("\n## ")
+            .map_or(content.len(), |pos| after_heading + pos);
+
+        let mut result = String::with_capacity(content.len());
+        result.push_str(&content[..heading_start]);
+        result.push_str(AI_SUMMARY_HEADING);
+        result.push_str("\n\n");
+        result.push_str(summary);
+        result.push('\n');
+
+        if section_end < content.len() {
+            result.push_str(&content[section_end..]);
+        }
+
+        // ensure trailing newline
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result
+    } else {
+        // セクションが存在しない → 末尾に追加
+        let mut result = content.clone();
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(AI_SUMMARY_HEADING);
+        result.push_str("\n\n");
+        result.push_str(summary);
+        result.push('\n');
+        result
+    };
+
+    std::fs::write(note_path, new_content)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -147,5 +206,75 @@ mod tests {
         assert!(content.contains("Custom template"));
         // tp.file.title should have been expanded to today's date
         assert!(!content.contains("tp.file.title"));
+    }
+
+    // ---- weekly_note_path ----
+
+    #[test]
+    fn weekly_note_path_format() {
+        let vault = Path::new("/vault");
+        let path = weekly_note_path(vault, "2026-W13");
+        assert_eq!(path, PathBuf::from("/vault/60_Weekly/2026-W13.md"));
+    }
+
+    // ---- append_ai_summary ----
+
+    #[test]
+    fn append_ai_summary_to_existing_section() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let note = tmp.path().join("note.md");
+        fs::write(&note, "# 2026-W13\n\n## 振り返り\n\n- ok\n\n## AI 週次サマリ\n\n古いサマリ\n").expect("write");
+
+        append_ai_summary(&note, "新しいサマリ").expect("append");
+        let content = fs::read_to_string(&note).expect("read");
+        assert!(content.contains("新しいサマリ"));
+        assert!(!content.contains("古いサマリ"));
+        assert!(content.contains("## 振り返り"));
+        assert!(content.ends_with('\n'));
+    }
+
+    #[test]
+    fn append_ai_summary_to_file_without_section() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let note = tmp.path().join("note.md");
+        let review_heading = "## \u{632F}\u{308A}\u{8FD4}\u{308A}";
+        fs::write(&note, format!("# 2026-W13\n\n{review_heading}\n\n- ok\n")).expect("write");
+
+        append_ai_summary(&note, "新規サマリ").expect("append");
+        let content = fs::read_to_string(&note).expect("read");
+        assert!(content.contains("## AI 週次サマリ\n\n新規サマリ\n"));
+        assert!(content.contains(review_heading));
+        assert!(content.ends_with('\n'));
+    }
+
+    #[test]
+    fn append_ai_summary_preserves_following_sections() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let note = tmp.path().join("note.md");
+        fs::write(
+            &note,
+            "# 2026-W13\n\n## AI 週次サマリ\n\n古い内容\n\n## メモ\n\n残す内容\n",
+        ).expect("write");
+
+        append_ai_summary(&note, "更新サマリ").expect("append");
+        let content = fs::read_to_string(&note).expect("read");
+        assert!(content.contains("更新サマリ"));
+        assert!(!content.contains("古い内容"));
+        assert!(content.contains("## メモ\n\n残す内容"));
+    }
+
+    #[test]
+    fn append_ai_summary_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let note = tmp.path().join("note.md");
+        fs::write(&note, "# 2026-W13\n").expect("write");
+
+        append_ai_summary(&note, "サマリA").expect("first");
+        append_ai_summary(&note, "サマリB").expect("second");
+        let content = fs::read_to_string(&note).expect("read");
+        assert!(content.contains("サマリB"));
+        assert!(!content.contains("サマリA"));
+        // Only one heading
+        assert_eq!(content.matches("## AI 週次サマリ").count(), 1);
     }
 }

--- a/src-tauri/src/task_parser.rs
+++ b/src-tauri/src/task_parser.rs
@@ -466,12 +466,12 @@ pub fn build_weekly_tasks(vault_root: &Path, week_offset: i32) -> anyhow::Result
 
 #[derive(Debug, Serialize)]
 pub struct WeeklyTaskSummary {
-    pub completed: Vec<CompletedTaskInfo>,
-    pub started: Vec<CompletedTaskInfo>,
+    pub completed: Vec<WeeklyTaskItem>,
+    pub started: Vec<WeeklyTaskItem>,
 }
 
 #[derive(Debug, Serialize)]
-pub struct CompletedTaskInfo {
+pub struct WeeklyTaskItem {
     pub text: String,
     pub project: String,
     pub done_date: Option<NaiveDate>,
@@ -500,7 +500,7 @@ pub fn parse_iso_week(week_str: &str) -> anyhow::Result<(NaiveDate, NaiveDate)> 
 }
 
 /// 指定週の完了・開始タスクを収集する（AI サマリ生成用）
-pub fn collect_weekly_done_tasks(
+pub fn collect_weekly_tasks(
     vault_root: &Path,
     week_start: NaiveDate,
     week_end: NaiveDate,
@@ -521,14 +521,14 @@ pub fn collect_weekly_done_tasks(
             let in_range = |d: NaiveDate| d >= week_start && d <= week_end;
 
             if task.status == TaskStatus::Done && task.done_date.is_some_and(in_range) {
-                completed.push(CompletedTaskInfo {
+                completed.push(WeeklyTaskItem {
                     text: task.text,
                     project: project.clone(),
                     done_date: task.done_date,
                     start: task.start,
                 });
             } else if task.status == TaskStatus::InProgress && task.start.is_some_and(in_range) {
-                started.push(CompletedTaskInfo {
+                started.push(WeeklyTaskItem {
                     text: task.text,
                     project: project.clone(),
                     done_date: task.done_date,
@@ -1038,14 +1038,14 @@ mod tests {
         assert!(parse_iso_week("2026-W54").is_err());
     }
 
-    // ---- collect_weekly_done_tasks ----
+    // ---- collect_weekly_tasks ----
 
     #[test]
     fn collect_done_tasks_empty_vault() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let mon = NaiveDate::from_ymd_opt(2026, 3, 23).expect("date");
         let sun = mon + Duration::days(6);
-        let summary = collect_weekly_done_tasks(tmp.path(), mon, sun).expect("collect");
+        let summary = collect_weekly_tasks(tmp.path(), mon, sun).expect("collect");
         assert!(summary.completed.is_empty());
         assert!(summary.started.is_empty());
     }
@@ -1069,7 +1069,7 @@ mod tests {
         .expect("write");
 
         let sun = mon + Duration::days(6);
-        let summary = collect_weekly_done_tasks(tmp.path(), mon, sun).expect("collect");
+        let summary = collect_weekly_tasks(tmp.path(), mon, sun).expect("collect");
         assert_eq!(summary.completed.len(), 1);
         assert_eq!(summary.completed[0].text, "In-week done");
         assert_eq!(summary.completed[0].project, "Proj");
@@ -1101,7 +1101,7 @@ mod tests {
         .expect("write");
 
         let sun = mon + Duration::days(6);
-        let summary = collect_weekly_done_tasks(tmp.path(), mon, sun).expect("collect");
+        let summary = collect_weekly_tasks(tmp.path(), mon, sun).expect("collect");
         assert_eq!(summary.completed.len(), 2);
     }
 }

--- a/src-tauri/src/task_parser.rs
+++ b/src-tauri/src/task_parser.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, Duration, NaiveDate};
+use chrono::{Datelike, Duration, NaiveDate, Weekday};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -459,6 +459,88 @@ pub fn build_weekly_tasks(vault_root: &Path, week_offset: i32) -> anyhow::Result
         week_start,
         week_end,
         projects,
+    })
+}
+
+// ---- Weekly AI サマリ用タスク収集 ----
+
+#[derive(Debug, Serialize)]
+pub struct WeeklyTaskSummary {
+    pub completed: Vec<CompletedTaskInfo>,
+    pub started: Vec<CompletedTaskInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CompletedTaskInfo {
+    pub text: String,
+    pub project: String,
+    pub done_date: Option<NaiveDate>,
+    pub start: Option<NaiveDate>,
+}
+
+/// `"2026-W13"` 形式の ISO 週文字列を (月曜日, 日曜日) の `NaiveDate` ペアに変換する
+pub fn parse_iso_week(week_str: &str) -> anyhow::Result<(NaiveDate, NaiveDate)> {
+    let parts: Vec<&str> = week_str.split("-W").collect();
+    if parts.len() != 2 {
+        anyhow::bail!("invalid ISO week format: {week_str} (expected YYYY-Www)");
+    }
+
+    let year: i32 = parts[0]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid year in ISO week: {week_str}"))?;
+    let week: u32 = parts[1]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid week number in ISO week: {week_str}"))?;
+
+    let monday = NaiveDate::from_isoywd_opt(year, week, Weekday::Mon)
+        .ok_or_else(|| anyhow::anyhow!("out of range ISO week: {week_str}"))?;
+    let sunday = monday + Duration::days(6);
+
+    Ok((monday, sunday))
+}
+
+/// 指定週の完了・開始タスクを収集する（AI サマリ生成用）
+pub fn collect_weekly_done_tasks(
+    vault_root: &Path,
+    week_start: NaiveDate,
+    week_end: NaiveDate,
+) -> anyhow::Result<WeeklyTaskSummary> {
+    let vault_files = walk_vault_tasks(vault_root)?;
+
+    let mut completed = Vec::new();
+    let mut started = Vec::new();
+
+    for vf in vault_files {
+        let project = Path::new(&vf.rel_path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        for task in vf.tasks {
+            let in_range = |d: NaiveDate| d >= week_start && d <= week_end;
+
+            if task.status == TaskStatus::Done && task.done_date.is_some_and(in_range) {
+                completed.push(CompletedTaskInfo {
+                    text: task.text,
+                    project: project.clone(),
+                    done_date: task.done_date,
+                    start: task.start,
+                });
+            } else if task.status == TaskStatus::InProgress && task.start.is_some_and(in_range) {
+                started.push(CompletedTaskInfo {
+                    text: task.text,
+                    project: project.clone(),
+                    done_date: task.done_date,
+                    start: task.start,
+                });
+            }
+        }
+    }
+
+    Ok(WeeklyTaskSummary {
+        completed,
+        started,
     })
 }
 
@@ -924,5 +1006,102 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].text, "Match");
         assert_eq!(result[1].text, "Child");
+    }
+
+    // ---- parse_iso_week ----
+
+    #[test]
+    fn parse_iso_week_valid() {
+        let (mon, sun) = parse_iso_week("2026-W13").expect("parse");
+        assert_eq!(mon, NaiveDate::from_ymd_opt(2026, 3, 23).expect("date"));
+        assert_eq!(sun, NaiveDate::from_ymd_opt(2026, 3, 29).expect("date"));
+    }
+
+    #[test]
+    fn parse_iso_week_week01() {
+        let (mon, sun) = parse_iso_week("2026-W01").expect("parse");
+        assert_eq!(mon, NaiveDate::from_ymd_opt(2025, 12, 29).expect("date"));
+        assert_eq!(sun, NaiveDate::from_ymd_opt(2026, 1, 4).expect("date"));
+    }
+
+    #[test]
+    fn parse_iso_week_week52() {
+        let (mon, _sun) = parse_iso_week("2025-W52").expect("parse");
+        assert_eq!(mon, NaiveDate::from_ymd_opt(2025, 12, 22).expect("date"));
+    }
+
+    #[test]
+    fn parse_iso_week_invalid_format() {
+        assert!(parse_iso_week("invalid").is_err());
+        assert!(parse_iso_week("2026-13").is_err());
+        assert!(parse_iso_week("2026-W00").is_err());
+        assert!(parse_iso_week("2026-W54").is_err());
+    }
+
+    // ---- collect_weekly_done_tasks ----
+
+    #[test]
+    fn collect_done_tasks_empty_vault() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mon = NaiveDate::from_ymd_opt(2026, 3, 23).expect("date");
+        let sun = mon + Duration::days(6);
+        let summary = collect_weekly_done_tasks(tmp.path(), mon, sun).expect("collect");
+        assert!(summary.completed.is_empty());
+        assert!(summary.started.is_empty());
+    }
+
+    #[test]
+    fn collect_done_tasks_filters_by_done_date() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let projects = tmp.path().join("10_Projects");
+        fs::create_dir_all(&projects).expect("mkdir");
+
+        let mon = NaiveDate::from_ymd_opt(2026, 3, 23).expect("date");
+        let wed = mon + Duration::days(2);
+        let prev = mon - Duration::days(3);
+
+        fs::write(
+            projects.join("Proj.md"),
+            format!(
+                "- [x] In-week done ✅ {wed}\n- [x] Out-of-week done ✅ {prev}\n- [/] In progress 🛫 {wed}\n"
+            ),
+        )
+        .expect("write");
+
+        let sun = mon + Duration::days(6);
+        let summary = collect_weekly_done_tasks(tmp.path(), mon, sun).expect("collect");
+        assert_eq!(summary.completed.len(), 1);
+        assert_eq!(summary.completed[0].text, "In-week done");
+        assert_eq!(summary.completed[0].project, "Proj");
+        // started: InProgress task with start in range
+        assert_eq!(summary.started.len(), 1);
+        assert_eq!(summary.started[0].text, "In progress");
+    }
+
+    #[test]
+    fn collect_done_tasks_includes_all_folders() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let inbox = tmp.path().join("00_Inbox");
+        let projects = tmp.path().join("10_Projects");
+        fs::create_dir_all(&inbox).expect("mkdir");
+        fs::create_dir_all(&projects).expect("mkdir");
+
+        let mon = NaiveDate::from_ymd_opt(2026, 3, 23).expect("date");
+        let tue = mon + Duration::days(1);
+
+        fs::write(
+            inbox.join("stuff.md"),
+            format!("- [x] Inbox done ✅ {tue}\n"),
+        )
+        .expect("write");
+        fs::write(
+            projects.join("Alpha.md"),
+            format!("- [x] Project done ✅ {mon}\n"),
+        )
+        .expect("write");
+
+        let sun = mon + Duration::days(6);
+        let summary = collect_weekly_done_tasks(tmp.path(), mon, sun).expect("collect");
+        assert_eq!(summary.completed.len(), 2);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,11 @@ export default function App() {
 
 	useEffect(() => {
 		if (vaultRoot) {
-			getAiAvailability().then(setAiAvailable);
+			getAiAvailability()
+				.then(setAiAvailable)
+				.catch(() => setAiAvailable(false));
+		} else {
+			setAiAvailable(false);
 		}
 	}, [vaultRoot, getAiAvailability]);
 
@@ -55,18 +59,25 @@ export default function App() {
 		}
 	}
 
-	const openInObsidian = useCallback(async (path: string) => {
-		const confirmed = await ask(`${path}\n\nObsidian で開きますか？`, {
-			title: "Note",
-			kind: "info",
-			okLabel: "開く",
-			cancelLabel: "閉じる",
-		});
-		if (confirmed) {
-			const url = `obsidian://open?path=${encodeURIComponent(path)}`;
-			await shellOpen(url);
-		}
-	}, []);
+	const openInObsidian = useCallback(
+		async (path: string) => {
+			try {
+				const confirmed = await ask(`${path}\n\nObsidian で開きますか？`, {
+					title: "Note",
+					kind: "info",
+					okLabel: "開く",
+					cancelLabel: "閉じる",
+				});
+				if (confirmed) {
+					const url = `obsidian://open?path=${encodeURIComponent(path)}`;
+					await shellOpen(url);
+				}
+			} catch (e) {
+				setError(String(e));
+			}
+		},
+		[setError],
+	);
 
 	async function handleCreateNote(kind: NoteKind) {
 		try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@
 
 import { ask, open } from "@tauri-apps/plugin-dialog";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { AiSummaryDialog } from "./components/AiSummaryDialog";
 import { Header } from "./components/Header";
 import { Sidebar } from "./components/Sidebar";
 import { SummaryView } from "./components/SummaryView";
@@ -25,9 +26,15 @@ export default function App() {
 		createNote,
 		getAiAvailability,
 		generateWeeklySummary,
+		saveWeeklySummary,
 	} = useVault();
 
 	const [aiAvailable, setAiAvailable] = useState(false);
+	const [aiPreview, setAiPreview] = useState<{
+		week: string;
+		summary: string | null; // null = 生成中
+		notePath: string;
+	} | null>(null);
 
 	const [activeView, setActiveView] = useState<ViewId>("summary");
 
@@ -47,6 +54,19 @@ export default function App() {
 			setError(String(e));
 		}
 	}
+
+	const openInObsidian = useCallback(async (path: string) => {
+		const confirmed = await ask(`${path}\n\nObsidian で開きますか？`, {
+			title: "Note",
+			kind: "info",
+			okLabel: "開く",
+			cancelLabel: "閉じる",
+		});
+		if (confirmed) {
+			const url = `obsidian://open?path=${encodeURIComponent(path)}`;
+			await shellOpen(url);
+		}
+	}, []);
 
 	async function handleCreateNote(kind: NoteKind) {
 		try {
@@ -68,33 +88,51 @@ export default function App() {
 				if (generateAi) {
 					const weekMatch = res.path.match(/(\d{4}-W\d{2})\.md$/);
 					if (weekMatch) {
+						setAiPreview({
+							week: weekMatch[1],
+							summary: null,
+							notePath: res.path,
+						});
 						try {
-							await generateWeeklySummary(weekMatch[1]);
+							const summaryText = await generateWeeklySummary(weekMatch[1]);
+							setAiPreview((prev) =>
+								prev ? { ...prev, summary: summaryText } : null,
+							);
+							return;
 						} catch (e) {
+							setAiPreview(null);
 							setError(`AI サマリ生成エラー: ${String(e)}`);
 						}
 					}
 				}
 			}
 
-			const confirmed = await ask(`${res.path}\n\nObsidian で開きますか？`, {
-				title: label,
-				kind: "info",
-				okLabel: "開く",
-				cancelLabel: "閉じる",
-			});
-			if (confirmed) {
-				try {
-					const url = `obsidian://open?path=${encodeURIComponent(res.path)}`;
-					await shellOpen(url);
-				} catch (e) {
-					setError(String(e));
-				}
-			}
+			await openInObsidian(res.path);
 		} catch (e) {
 			setError(String(e));
 		}
 	}
+
+	const handleAiConfirm = useCallback(async () => {
+		if (!aiPreview?.summary) return;
+		const { notePath } = aiPreview;
+		try {
+			await saveWeeklySummary(aiPreview.week, aiPreview.summary);
+		} catch (e) {
+			setError(`AI サマリ保存エラー: ${String(e)}`);
+			return; // 保存失敗時はダイアログを閉じない
+		}
+		setAiPreview(null);
+		await openInObsidian(notePath);
+	}, [aiPreview, saveWeeklySummary, setError, openInObsidian]);
+
+	const handleAiCancel = useCallback(async () => {
+		const notePath = aiPreview?.notePath;
+		setAiPreview(null);
+		if (notePath) {
+			await openInObsidian(notePath);
+		}
+	}, [aiPreview, openInObsidian]);
 
 	// Vault 未設定時
 	if (!vaultRoot) {
@@ -169,6 +207,14 @@ export default function App() {
 						))}
 				</main>
 			</div>
+
+			{aiPreview && (
+				<AiSummaryDialog
+					summary={aiPreview.summary}
+					onConfirm={handleAiConfirm}
+					onCancel={handleAiCancel}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 
 import { ask, open } from "@tauri-apps/plugin-dialog";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Header } from "./components/Header";
 import { Sidebar } from "./components/Sidebar";
 import { SummaryView } from "./components/SummaryView";
@@ -23,9 +23,19 @@ export default function App() {
 		setError,
 		setVaultRoot,
 		createNote,
+		getAiAvailability,
+		generateWeeklySummary,
 	} = useVault();
 
+	const [aiAvailable, setAiAvailable] = useState(false);
+
 	const [activeView, setActiveView] = useState<ViewId>("summary");
+
+	useEffect(() => {
+		if (vaultRoot) {
+			getAiAvailability().then(setAiAvailable);
+		}
+	}, [vaultRoot, getAiAvailability]);
 
 	async function handleSelectVault() {
 		try {
@@ -43,10 +53,36 @@ export default function App() {
 			const res = await createNote(kind);
 			const label = kind === "daily" ? "Daily Note" : "Weekly Note";
 			const status = res.created ? "を作成しました" : "は既に存在します";
-			const confirmed = await ask(
-				`${label}${status}。\n${res.path}\n\nObsidian で開きますか？`,
-				{ title: label, kind: "info", okLabel: "開く", cancelLabel: "閉じる" },
-			);
+
+			// Weekly Note + AI 利用可能時はサマリ生成を提案
+			if (kind === "weekly" && aiAvailable) {
+				const generateAi = await ask(
+					`${label}${status}。\nAI 週次サマリを生成しますか？`,
+					{
+						title: label,
+						kind: "info",
+						okLabel: "生成する",
+						cancelLabel: "スキップ",
+					},
+				);
+				if (generateAi) {
+					const weekMatch = res.path.match(/(\d{4}-W\d{2})\.md$/);
+					if (weekMatch) {
+						try {
+							await generateWeeklySummary(weekMatch[1]);
+						} catch (e) {
+							setError(`AI サマリ生成エラー: ${String(e)}`);
+						}
+					}
+				}
+			}
+
+			const confirmed = await ask(`${res.path}\n\nObsidian で開きますか？`, {
+				title: label,
+				kind: "info",
+				okLabel: "開く",
+				cancelLabel: "閉じる",
+			});
 			if (confirmed) {
 				try {
 					const url = `obsidian://open?path=${encodeURIComponent(res.path)}`;

--- a/src/components/AiSummaryDialog.tsx
+++ b/src/components/AiSummaryDialog.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { type CSSProperties, useCallback, useEffect } from "react";
 
 /** AI 週次サマリのプレビュー・確認ダイアログ */
 export function AiSummaryDialog({
@@ -12,10 +12,31 @@ export function AiSummaryDialog({
 }) {
 	const loading = summary === null;
 
+	const handleKeyDown = useCallback(
+		(e: KeyboardEvent) => {
+			if (e.key === "Escape" && !loading) {
+				onCancel();
+			}
+		},
+		[loading, onCancel],
+	);
+
+	useEffect(() => {
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [handleKeyDown]);
+
 	return (
 		<div style={styles.overlay}>
-			<div style={styles.dialog}>
-				<h2 style={styles.heading}>AI 週次サマリ</h2>
+			<div
+				style={styles.dialog}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="ai-summary-title"
+			>
+				<h2 id="ai-summary-title" style={styles.heading}>
+					AI 週次サマリ
+				</h2>
 
 				{loading ? (
 					<div style={styles.loadingContainer}>
@@ -66,7 +87,17 @@ function markdownToHtml(md: string): string {
 	for (const line of lines) {
 		const trimmed = line.trim();
 
-		if (trimmed.startsWith("- ")) {
+		const headingMatch = /^(#{1,3})\s+(.+)$/.exec(trimmed);
+		if (headingMatch) {
+			if (inList) {
+				parts.push("</ul>");
+				inList = false;
+			}
+			const level = headingMatch[1].length;
+			parts.push(
+				`<h${level + 1}>${escapeHtml(headingMatch[2])}</h${level + 1}>`,
+			);
+		} else if (trimmed.startsWith("- ")) {
 			if (!inList) {
 				parts.push("<ul>");
 				inList = true;

--- a/src/components/AiSummaryDialog.tsx
+++ b/src/components/AiSummaryDialog.tsx
@@ -1,0 +1,187 @@
+import type { CSSProperties } from "react";
+
+/** AI 週次サマリのプレビュー・確認ダイアログ */
+export function AiSummaryDialog({
+	summary,
+	onConfirm,
+	onCancel,
+}: {
+	summary: string | null; // null = 生成中
+	onConfirm: () => void;
+	onCancel: () => void;
+}) {
+	const loading = summary === null;
+
+	return (
+		<div style={styles.overlay}>
+			<div style={styles.dialog}>
+				<h2 style={styles.heading}>AI 週次サマリ</h2>
+
+				{loading ? (
+					<div style={styles.loadingContainer}>
+						<div className="ai-spinner" />
+						<span style={styles.loadingText}>生成中…</span>
+					</div>
+				) : (
+					<div
+						style={styles.content}
+						className="ai-summary-content"
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: markdown preview from local AI
+						dangerouslySetInnerHTML={{ __html: markdownToHtml(summary) }}
+					/>
+				)}
+
+				<div style={styles.actions}>
+					<button
+						type="button"
+						style={styles.cancelButton}
+						onClick={onCancel}
+						disabled={loading}
+					>
+						破棄
+					</button>
+					<button
+						type="button"
+						style={{
+							...styles.confirmButton,
+							...(loading ? styles.disabledButton : {}),
+						}}
+						onClick={onConfirm}
+						disabled={loading}
+					>
+						追記する
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/** Markdown のサブセットを HTML に変換する（太字・箇条書き・段落） */
+function markdownToHtml(md: string): string {
+	const lines = md.split("\n");
+	const parts: string[] = [];
+	let inList = false;
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+
+		if (trimmed.startsWith("- ")) {
+			if (!inList) {
+				parts.push("<ul>");
+				inList = true;
+			}
+			parts.push(`<li>${inlineFormat(trimmed.slice(2))}</li>`);
+		} else {
+			if (inList) {
+				parts.push("</ul>");
+				inList = false;
+			}
+			if (trimmed !== "") {
+				parts.push(`<p>${inlineFormat(trimmed)}</p>`);
+			}
+		}
+	}
+
+	if (inList) {
+		parts.push("</ul>");
+	}
+
+	return parts.join("");
+}
+
+function escapeHtml(text: string): string {
+	return text
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#039;");
+}
+
+function inlineFormat(text: string): string {
+	const escaped = escapeHtml(text);
+	return escaped.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+}
+
+const styles: Record<string, CSSProperties> = {
+	overlay: {
+		position: "fixed",
+		inset: 0,
+		background: "rgba(0, 0, 0, 0.5)",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		zIndex: 100,
+	},
+	dialog: {
+		maxWidth: 560,
+		width: "90vw",
+		maxHeight: "70vh",
+		display: "flex",
+		flexDirection: "column",
+		background: "var(--card-bg)",
+		color: "var(--text)",
+		border: "1px solid var(--border)",
+		borderRadius: 12,
+		padding: 0,
+		overflow: "hidden",
+	},
+	heading: {
+		fontSize: "var(--font-base)",
+		fontWeight: 600,
+		margin: 0,
+		padding: "16px 20px 12px",
+		borderBottom: "1px solid var(--border)",
+	},
+	content: {
+		flex: 1,
+		overflow: "auto",
+		padding: "16px 20px",
+		fontSize: "var(--font-sm)",
+		lineHeight: 1.7,
+	},
+	loadingContainer: {
+		flex: 1,
+		display: "flex",
+		flexDirection: "column",
+		alignItems: "center",
+		justifyContent: "center",
+		padding: "48px 20px",
+		gap: 16,
+	},
+	loadingText: {
+		color: "var(--text-muted)",
+		fontSize: "var(--font-sm)",
+	},
+	actions: {
+		display: "flex",
+		justifyContent: "flex-end",
+		gap: 8,
+		padding: "12px 20px",
+		borderTop: "1px solid var(--border)",
+	},
+	cancelButton: {
+		background: "transparent",
+		color: "var(--text-muted)",
+		border: "1px solid var(--border)",
+		borderRadius: 6,
+		padding: "7px 16px",
+		fontSize: "var(--font-sm)",
+		cursor: "pointer",
+	},
+	confirmButton: {
+		background: "var(--accent)",
+		color: "#fff",
+		border: "none",
+		borderRadius: 6,
+		padding: "7px 16px",
+		fontSize: "var(--font-sm)",
+		fontWeight: 500,
+		cursor: "pointer",
+	},
+	disabledButton: {
+		opacity: 0.4,
+		cursor: "not-allowed",
+	},
+};

--- a/src/hooks/useVault.ts
+++ b/src/hooks/useVault.ts
@@ -99,6 +99,13 @@ export function useVault() {
 		return invoke<boolean>("get_ai_availability");
 	}, []);
 
+	const generateWeeklySummary = useCallback(
+		async (week: string): Promise<string> => {
+			return invoke<string>("generate_weekly_summary", { week });
+		},
+		[],
+	);
+
 	const createNote = useCallback(
 		async (kind: NoteKind): Promise<CreateNoteResponse> => {
 			return invoke<CreateNoteResponse>("create_note", {
@@ -127,5 +134,6 @@ export function useVault() {
 		createNote,
 		refreshSummary,
 		getAiAvailability,
+		generateWeeklySummary,
 	};
 }

--- a/src/hooks/useVault.ts
+++ b/src/hooks/useVault.ts
@@ -106,6 +106,13 @@ export function useVault() {
 		[],
 	);
 
+	const saveWeeklySummary = useCallback(
+		async (week: string, summary: string): Promise<void> => {
+			await invoke("save_weekly_summary", { week, summary });
+		},
+		[],
+	);
+
 	const createNote = useCallback(
 		async (kind: NoteKind): Promise<CreateNoteResponse> => {
 			return invoke<CreateNoteResponse>("create_note", {
@@ -135,5 +142,6 @@ export function useVault() {
 		refreshSummary,
 		getAiAvailability,
 		generateWeeklySummary,
+		saveWeeklySummary,
 	};
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,34 @@ body {
 	user-select: none;
 }
 
+.ai-spinner {
+	width: 28px;
+	height: 28px;
+	border: 3px solid var(--border);
+	border-top-color: var(--accent);
+	border-radius: 50%;
+	animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.ai-summary-content p {
+	margin: 0 0 0.6em;
+}
+
+.ai-summary-content p:last-child {
+	margin-bottom: 0;
+}
+
+.ai-summary-content ul {
+	margin: 0 0 0.6em;
+	padding-left: 1.4em;
+}
+
 button:hover {
 	opacity: 0.85;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,6 +61,14 @@ body {
 	}
 }
 
+.ai-summary-content h2,
+.ai-summary-content h3,
+.ai-summary-content h4 {
+	margin: 0.8em 0 0.3em;
+	font-size: var(--font-sm);
+	font-weight: 600;
+}
+
 .ai-summary-content p {
 	margin: 0 0 0.6em;
 }


### PR DESCRIPTION
## 変更の概要

Weekly Note 作成時に、Apple Intelligence を使って週次振り返りサマリを自動生成し、
ノートに追記する機能を追加しました。
生成結果はカスタムモーダルでプレビュー・確認してから保存できます。

## 主な変更点

- `task_parser.rs`: ISO 週パース (`parse_iso_week`) と週次タスク収集 (`collect_weekly_done_tasks`) を追加
- `note_creator.rs`: AI サマリセクションの追記・上書き (`append_ai_summary`) を実装。
  デリミタ (`<!-- /ai-weekly-summary -->`) でセクション範囲を管理
- `lib.rs`: `generate_weekly_summary`（生成のみ）と `save_weekly_summary`（追記）の 2 コマンドを追加
- `ai_bridge.rs`: `generate` 関数を `pub use` で公開
- `AiSummaryDialog.tsx`: Markdown プレビュー付きカスタムモーダルを新規作成。
  生成中のスピナーアニメーション、HTML エスケープ対応
- `App.tsx`: Weekly Note 作成フローに AI サマリ生成→プレビュー→確認→保存の一連のフローを追加
- `useVault.ts`: `generateWeeklySummary` / `saveWeeklySummary` を追加

## 変更の背景

- Closes #19
- Apple Intelligence の Swift ブリッジ基盤 (#21) を活用した最初の機能実装です。
  週次の完了・進行中タスクを集計し、on-device AI でプロジェクト別のサマリを生成します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 週次ノートのAIサマリ自動生成と、そのプレビュー確認後にノートへ追記する機能を追加。作成フローから生成・保存までを操作可能にしました。
  * 生成中の表示（スピナー）とフルスクリーンのプレビュー/確認ダイアログを導入。

* **ドキュメント**
  * 新しいAIコマンドの操作説明を追加しました。

* **テスト**
  * 週次ノート追記やタスク収集の挙動をカバーするユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->